### PR TITLE
Fix crash on newer Node.js versions and extend API

### DIFF
--- a/AppleLogin.m
+++ b/AppleLogin.m
@@ -1,4 +1,5 @@
 #import "AppleLogin.h"
+
 @interface AppleLogin ()
 
 @property (nonatomic, strong) NSWindow *window;
@@ -32,6 +33,7 @@
 
     if(appleIDCredential) {
       NSString *idToken = [[NSString alloc] initWithData:appleIDCredential.identityToken encoding:NSUTF8StringEncoding];
+      NSString *code = [[NSString alloc] initWithData:appleIDCredential.authorizationCode encoding:NSUTF8StringEncoding];
 
       NSPersonNameComponents *fullName = appleIDCredential.fullName;
       NSDictionary *userDetails = @{
@@ -40,6 +42,7 @@
         @"lastName": fullName.familyName ?: @"",
         @"email" : appleIDCredential.email ?: @"",
         @"idToken" : idToken,
+        @"code" : code,
       };
 
       self.successBlock(userDetails);

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ ipcMain.on('sign-in-with-apple', async () => {
     const data = await signInWithApple(nativeWindow);
     // {
     //   idToken: 'TOKEN',
+    //   code: 'CODE',
     //   firstName: 'John',
     //   middleName: 'Chris',
     //   lastName: 'Doe',

--- a/index.js
+++ b/index.js
@@ -5,7 +5,18 @@ const signInWithApple = async (mainWindow) => {
     throw new Error('node-mac-sign-in-with-apple only works on macOS')
   }
 
-  return await appleLogin.signInWithApple(mainWindow);
+  return new Promise((resolve, reject) => {
+    appleLogin.signInWithApple((result) => {
+      if (result.is_error === 'true') {
+        delete result.is_error;
+        reject(result);
+        return;
+      }
+
+      delete result.is_error;
+      resolve(result);
+    }, mainWindow);
+  })
 };
 
 module.exports = {


### PR DESCRIPTION
This PR updates the Node.js bindings in the repo so it won't crash on newer versions.

It also adds an extra `code` field to be returned to the API.